### PR TITLE
Add XLSX saving support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# ExcelFiles.jl v0.6.1
+* Work around bug in pkg registry conversion script
+
 # ExcelFiles.jl v0.6.0
 * Drop julia 0.6 support, add julia 0.7 support
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ DataValues 0.4.4
 FileIO 1.0.0
 TableShowUtils 0.1.1
 XLSX 0.4.1
+DataFrames 0.14.1

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ IterableTables 0.8.3
 DataValues 0.4.4
 FileIO 1.0.0
 TableShowUtils 0.1.1
+XLSX 0.4.1

--- a/src/ExcelFiles.jl
+++ b/src/ExcelFiles.jl
@@ -1,8 +1,8 @@
 module ExcelFiles
 
 
-using ExcelReaders, IteratorInterfaceExtensions, TableTraits, DataValues,
-    TableTraitsUtils, FileIO, TableShowUtils, Dates, Printf
+using ExcelReaders, IteratorInterfaceExtensions, TableTraits, DataValues
+using TableTraitsUtils, FileIO, TableShowUtils, Dates, Printf
 import IterableTables
 
 export load, save

--- a/src/ExcelFiles.jl
+++ b/src/ExcelFiles.jl
@@ -23,13 +23,13 @@ end
 
 Base.Multimedia.showable(::MIME"text/html", source::ExcelFile) = true
 
-function fileio_save(f::FileIO.File{FileIO.format"Excel"}, data)
-    cols, colnames = TableTraitsUtils.create_columns_from_iterabletable(data)
-    return XLSX.writetable(f.filename, cols, colnames)
-end
-
 function fileio_load(f::FileIO.File{FileIO.format"Excel"}, range; keywords...)
     return ExcelFile(f.filename, range, keywords)
+end
+
+function fileio_save(f::FileIO.File{FileIO.format"Excel"}, data)
+    cols, colnames = TableTraitsUtils.create_columns_from_iterabletable(data, na_representation=:missing)
+    return XLSX.writetable(f.filename, cols, colnames)
 end
 
 IteratorInterfaceExtensions.isiterable(x::ExcelFile) = true

--- a/src/ExcelFiles.jl
+++ b/src/ExcelFiles.jl
@@ -1,7 +1,7 @@
 module ExcelFiles
 
 
-using ExcelReaders, IteratorInterfaceExtensions, TableTraits, DataValues
+using ExcelReaders, XLSX, IteratorInterfaceExtensions, TableTraits, DataValues
 using TableTraitsUtils, FileIO, TableShowUtils, Dates, Printf
 import IterableTables
 
@@ -22,6 +22,11 @@ function Base.show(io::IO, ::MIME"text/html", source::ExcelFile)
 end
 
 Base.Multimedia.showable(::MIME"text/html", source::ExcelFile) = true
+
+function fileio_save(f::FileIO.File{FileIO.format"Excel"}, data)
+    cols, colnames = TableTraitsUtils.create_columns_from_iterabletable(data)
+    return XLSX.writetable(f.filename, cols, colnames)
+end
 
 function fileio_load(f::FileIO.File{FileIO.format"Excel"}, range; keywords...)
     return ExcelFile(f.filename, range, keywords)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using TableTraits
 using TableTraitsUtils
 using Dates
 using DataValues
+using DataFrames
 using Test
 
 @testset "ExcelFiles" begin
@@ -87,11 +88,19 @@ df, names = create_columns_from_iterabletable(load(filename, "Sheet1!C4:O7", hea
 @test DataValues.isna(df[12][4])
 @test df[13] == [NA, 3.4, "HKEJW", NA]
 
+# Test for saving DataFrame to XLSX
+input = (Day=["Nov. 27","Nov. 28","Nov. 29"], Highest=[78,79,75]) |> DataFrame
+file = save("file.xlsx", input)
+output = load("file.xlsx", "Sheet1!A1:B4", header=true) |> DataFrame
+print(input == output)
+rm("file.xlsx")
+
 # Too few colnames
 @test_throws ErrorException create_columns_from_iterabletable(load(filename, "Sheet1!C4:O7", header=true, colnames=[:c1, :c2, :c3, :c4]))
 
 # Test for constructing DataFrame with empty header cell
 data, names = create_columns_from_iterabletable(load(filename, "Sheet2!C5:E7"))
 @test names == [:Col1, :x1, :Col3]
+
 
 end


### PR DESCRIPTION
Do not merge because this requires modification in XLSX library to work.
We added the following code to make it work:
`setdata!(ws::Worksheet, ref::CellRef, val::DataValue) = setdata!(ws, ref, val.value)`

We are working on it to get the conversion done in this library.